### PR TITLE
Log gleaner gets assertion failure on kicked twice.

### DIFF
--- a/foedus-core/src/foedus/storage/masstree/masstree_partitioner_impl.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_partitioner_impl.cpp
@@ -74,6 +74,9 @@ ErrorStack MasstreePartitioner::design_partition(
   MasstreeIntermediatePage* vol = reinterpret_cast<MasstreeIntermediatePage*>(buffers);
   MasstreeIntermediatePage* snp = reinterpret_cast<MasstreeIntermediatePage*>(buffers + 1);
   SnapshotPagePointer snapshot_page_id = control_block->root_page_pointer_.snapshot_pointer_;
+  if (control_block->root_page_pointer_.volatile_pointer_.word == 0) {
+    return kRetOk;
+  }
   MasstreeIntermediatePage* root_volatile = reinterpret_cast<MasstreeIntermediatePage*>(
     resolver.resolve_offset(control_block->root_page_pointer_.volatile_pointer_));
   CHECK_ERROR(read_page_safe(root_volatile, vol));

--- a/tests-core/src/foedus/snapshot/test_snapshot_masstree.cpp
+++ b/tests-core/src/foedus/snapshot/test_snapshot_masstree.cpp
@@ -172,6 +172,7 @@ void test_run(
   bool multiple_loggers,
   bool multiple_partitions) {
   EngineOptions options = get_tiny_options();
+  options.snapshot_.snapshot_interval_milliseconds_ = 10;
   if (multiple_partitions) {
     options.thread_.thread_count_per_group_ = 1;
     options.thread_.group_count_ = 2;
@@ -210,6 +211,7 @@ void test_run(
       EXPECT_TRUE(out.exists());
       COERCE_ERROR(engine.get_thread_pool()->impersonate_synchronous(verify_name));
       EXPECT_TRUE(out.exists());
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
       engine.get_snapshot_manager()->trigger_snapshot_immediate(true);
       EXPECT_TRUE(out.exists());
 

--- a/tests-core/src/foedus/snapshot/test_snapshot_masstree.cpp
+++ b/tests-core/src/foedus/snapshot/test_snapshot_masstree.cpp
@@ -172,7 +172,6 @@ void test_run(
   bool multiple_loggers,
   bool multiple_partitions) {
   EngineOptions options = get_tiny_options();
-  options.snapshot_.snapshot_interval_milliseconds_ = 10;
   if (multiple_partitions) {
     options.thread_.thread_count_per_group_ = 1;
     options.thread_.group_count_ = 2;
@@ -211,8 +210,8 @@ void test_run(
       EXPECT_TRUE(out.exists());
       COERCE_ERROR(engine.get_thread_pool()->impersonate_synchronous(verify_name));
       EXPECT_TRUE(out.exists());
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
       engine.get_snapshot_manager()->trigger_snapshot_immediate(true);
+      engine.get_snapshot_manager()->trigger_snapshot_immediate(true);  // log gleaner must be idempotent.
       EXPECT_TRUE(out.exists());
 
       COERCE_ERROR(engine.uninitialize());


### PR DESCRIPTION
When snapshot taken by LogGleaner, we hit assertion-fail.

The test code used `engine.get_snapshot_manager()->trigger_snapshot_immediate(true);` does not find this error.

```
***************************************************************************
**** Assertion failed! "offset >= begin_" did not hold in resolve_offset_newpage(): ../foedus-core/include/foedus/memory/page_resolver.hpp:138
***************************************************************************
=== Stack frame (length=18)
- [0/18] in foedus::assorted::get_backtrace[abi:cxx11](bool) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8assorted13get_backtraceB5cxx11Eb+0x42) [0x7f3c5eb9c528] (libbacktrace: [0x7F3C5EEBEF27])
- [1/18] in foedus::print_backtrace[abi:cxx11]() : /usr/local/lib64/libfoedus-core.so(_ZN6foedus15print_backtraceB5cxx11Ev+0x3a) [0x7f3c5eebef28] (libbacktrace: [0x7F3C5EEBF166])
- [2/18] in foedus::print_assert_backtrace(char const*, char const*, int, char const*) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus22print_assert_backtraceEPKcS1_iS1_+0x51) [0x7f3c5eebf167] (libbacktrace: [0x7F3C5ED7A0A2])
- [3/18] in foedus::storage::masstree::MasstreePartitioner::design_partition(foedus::storage::Partitioner::DesignPartitionArguments const&) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus7storage8masstree19MasstreePartitioner16design_partitionERKNS0_11Partitioner24DesignPartitionArgumentsE+0x297) [0x7f3c5ed7a0a3] (libbacktrace: [0x7F3C5EDE5520])
- [4/18] in foedus::storage::Partitioner::design_partition(foedus::storage::Partitioner::DesignPartitionArguments const&) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus7storage11Partitioner16design_partitionERKNS1_24DesignPartitionArgumentsE+0x109) [0x7f3c5ede5521] (libbacktrace: [0x7F3C5EDEFA3F])
- [5/18] in foedus::snapshot::LogGleaner::design_partitions_run(unsigned int, unsigned int, foedus::ErrorStack*) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8snapshot10LogGleaner21design_partitions_runEjjPNS_10ErrorStackE+0x2d6) [0x7f3c5edefa40] (libbacktrace: [0x7F3C5EDEF72D])
- [6/18] in foedus::snapshot::LogGleaner::design_partitions() : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8snapshot10LogGleaner17design_partitionsEv+0x48) [0x7f3c5edef72e] (libbacktrace: [0x7F3C5EDEFF0D])
- [7/18] in foedus::snapshot::LogGleaner::execute() : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8snapshot10LogGleaner7executeEv+0x10c) [0x7f3c5edeff0e] (libbacktrace: [0x7F3C5EE5396B])
- [8/18] in foedus::snapshot::SnapshotManagerPimpl::glean_logs(foedus::snapshot::Snapshot const&, std::map<unsigned int, unsigned long, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, unsigned long> > >*) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8snapshot20SnapshotManagerPimpl10glean_logsERKNS0_8SnapshotEPSt3mapIjmSt4lessIjESaISt4pairIKjmEEE+0x82) [0x7f3c5ee5396c] (libbacktrace: [0x7F3C5EE533AC])
- [9/18] in foedus::snapshot::SnapshotManagerPimpl::handle_snapshot_triggered(foedus::snapshot::Snapshot*) : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8snapshot20SnapshotManagerPimpl25handle_snapshot_triggeredEPNS0_8SnapshotE+0x617) [0x7f3c5ee533ad] (libbacktrace: [0x7F3C5EE51E5F])
- [10/18] in foedus::snapshot::SnapshotManagerPimpl::handle_snapshot() : /usr/local/lib64/libfoedus-core.so(_ZN6foedus8snapshot20SnapshotManagerPimpl15handle_snapshotEv+0x428) [0x7f3c5ee51e60] (libbacktrace: [0x7F3C5EE5BE1A])
- [11/18] in void std::_Mem_fn_base<void (foedus::snapshot::SnapshotManagerPimpl::*)(), true>::operator()<, void>(foedus::snapshot::SnapshotManagerPimpl*) const : /usr/local/lib64/libfoedus-core.so(_ZNKSt12_Mem_fn_baseIMN6foedus8snapshot20SnapshotManagerPimplEFvvELb1EEclIJEvEEvPS2_DpOT_+0x65) [0x7f3c5ee5be1b] (libbacktrace: [0x7F3C5EE5BCDC])
- [12/18] in void std::_Bind_simple<std::_Mem_fn<void (foedus::snapshot::SnapshotManagerPimpl::*)()> (foedus::snapshot::SnapshotManagerPimpl*)>::_M_invoke<0ul>(std::_Index_tuple<0ul>) : /usr/local/lib64/libfoedus-core.so(_ZNSt12_Bind_simpleIFSt7_Mem_fnIMN6foedus8snapshot20SnapshotManagerPimplEFvvEEPS3_EE9_M_invokeIJLm0EEEEvSt12_Index_tupleIJXspT_EEE+0x43) [0x7f3c5ee5bcdd] (libbacktrace: [0x7F3C5EE5B9B5])
- [13/18] in std::_Bind_simple<std::_Mem_fn<void (foedus::snapshot::SnapshotManagerPimpl::*)()> (foedus::snapshot::SnapshotManagerPimpl*)>::operator()() : /usr/local/lib64/libfoedus-core.so(_ZNSt12_Bind_simpleIFSt7_Mem_fnIMN6foedus8snapshot20SnapshotManagerPimplEFvvEEPS3_EEclEv+0x2c) [0x7f3c5ee5b9b6] (libbacktrace: [0x7F3C5EE5B8BF])
- [14/18] in std::thread::_Impl<std::_Bind_simple<std::_Mem_fn<void (foedus::snapshot::SnapshotManagerPimpl::*)()> (foedus::snapshot::SnapshotManagerPimpl*)> >::_M_run() : /usr/local/lib64/libfoedus-core.so(_ZNSt6thread5_ImplISt12_Bind_simpleIFSt7_Mem_fnIMN6foedus8snapshot20SnapshotManagerPimplEFvvEEPS5_EEE6_M_runEv+0x1c) [0x7f3c5ee5b8c0] (libbacktrace: [0x7F3C5E261C7F])
- [15/18] in ??? : /usr/lib/x86_64-linux-gnu/libstdc++.so.6(+0xb8c80) [0x7f3c5e261c80] (libbacktrace: [0x7F3C5E5326B9])
- [16/18] in ??? : /lib/x86_64-linux-gnu/libpthread.so.0(+0x76ba) [0x7f3c5e5326ba] (libbacktrace: [0x7F3C5DCD03DC])
- [17/18] in clone : /lib/x86_64-linux-gnu/libc.so.6(clone+0x6d) [0x7f3c5dcd03dd]
foedus_test: ../foedus-core/include/foedus/memory/page_resolver.hpp:138: foedus::storage::Page* foedus::memory::GlobalVolatilePageResolver::resolve_offset_newpage(uint8_t, foedus::memory::PagePoolOffset) const: Assertion `offset >= begin_' failed.
```