### PR TITLE
logger prescreening is needed to avoid SEGV

### DIFF
--- a/experiments-core/src/foedus/tpcc/tpcc_driver.cpp
+++ b/experiments-core/src/foedus/tpcc/tpcc_driver.cpp
@@ -476,6 +476,7 @@ int driver_main(int argc, char **argv) {
   }
 
   EngineOptions options;
+  options.prescreen(&std::cout);
   if (FLAGS_suppress_memory_prescreen) {
     options.memory_.suppress_memory_prescreening_ = true;
   }

--- a/foedus-core/src/foedus/engine_options.cpp
+++ b/foedus-core/src/foedus/engine_options.cpp
@@ -128,9 +128,19 @@ ErrorStack EngineOptions::prescreen(std::ostream* details_out) const {
   std::stringstream out_buffer;
   const uint64_t kMarginRatio = 4;  // Add 1/4 to be safe
 
+
   // we don't stop prescreening on individual errors so that
   // the user can see all issues at once.
   bool has_any_error = false;
+
+  if (0 < thread_.thread_count_per_group_ % log_.loggers_per_node_) {
+    has_any_error = true;
+    out_buffer
+      << "[FOEDUS] ERROR. "
+      << "The number of loggers per node must be a submultiple "
+      << "of the number of cores in the node. Check the settings in LogOptions"
+      << std::endl;
+  }
 
   if (RUNNING_ON_VALGRIND && memory_.rigorous_page_boundary_check_) {
     out_buffer

--- a/foedus-core/src/foedus/log/log_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/log/log_manager_pimpl.cpp
@@ -165,11 +165,12 @@ ErrorStack LogManagerPimpl::uninitialize_once() {
   }
   batch.uninitialize_and_delete_all(&loggers_);
   logger_refs_.clear();
-  if (engine_->is_master()) {
+  if (engine_->is_master() && control_block_ != nullptr) {
     control_block_->uninitialize();
   }
   return SUMMARIZE_ERROR_BATCH(batch);
 }
+
 void LogManagerPimpl::wakeup_loggers() {
   for (LoggerRef& logger : logger_refs_) {
     logger.wakeup();


### PR DESCRIPTION
`logger` count must be submultiple of `threads per node`.
if not, it will uninitialize it.
so tpcc benchmark unintializes `controlblock` even if it is not initialized! it cause SEGV.
We should prescreen it before initializing engine.