### PR TITLE
`cpplint` tasks does not work if it raises too many diagnostics.

### DIFF
--- a/foedus-core/tools/cpplint-wrapper.py
+++ b/foedus-core/tools/cpplint-wrapper.py
@@ -179,7 +179,6 @@ def exec_cpplint(files, cpplint_arguments):
     # sys.stdout.write('Launching cpplint (' + cpplint_file + ') for ' + str(len(files))
     #                  + ' files. arguments: ' + ' '.join(args) + '\n')
     proc = subprocess.Popen(args, bufsize=65536, stderr=subprocess.PIPE, close_fds=True)
-    proc.wait()
     has_error = False
     clean_index = {}
     clean_index.update(index_last)
@@ -199,6 +198,7 @@ def exec_cpplint(files, cpplint_arguments):
               sys.stderr.write('\033[93m' + line + '\033[0m') # Put a color that stands out
             else:
               sys.stderr.write(line) # If the client (kdevelop?) doesn't support, avoid it.
+    proc.wait()
 
     # store the clean list to speed up next execution
     store_dir_index(clean_index, history_file)


### PR DESCRIPTION
This PR fixes `cpplint_*` tasks that potentially deadlock if they raise too many diagnostics.

To reproduce this, please checkout the source tree with CR+LF line ending and then build the project.